### PR TITLE
Add inflation adjustment note with span node

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -155,6 +155,10 @@ p.header-label {
   fill: #848484;
 }
 
+#char-display-parenthetical {
+  color: darkred;
+}
+
 /*Legends*/
 
 .legend-color-box {

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       </div>
       <div class="col-md-4">
         <p class="header-label">Selected Characteristic</p>
-        <h4 id="char-display-name"></h4>
+        <h4><span id="char-display-name"></span> <span id="char-display-parenthetical"></span></h4>
         <p id="char-about"></p>
       </div>
       <div id="legend" class="col-md-4">

--- a/js/characteristics.js
+++ b/js/characteristics.js
@@ -37,6 +37,7 @@ var characteristics = { // eslint-disable-line
   },
   earnings: {
     displayName: 'Earnings',
+    displayParenthetical: '(In constant 2014 US dollars)',
     colors: ['#a6d1f8', '#012e60'],
     about: 'Earnings may change considerably when a person migrates, and these data represent only the amount a worker earns at their destination. Workers with earnings between $25,000 and $50,000 experienced net outflows in every decade, except the most recent, where the net inflow was 12,000. The same trajectory was true for workers with earning between $75,000 and $150,000, and for those earning $150,000 and over. These data indicate that the highest earners are currently coming to the city in larger numbers than previously, with a net migration that has turned slightly positive, a first in the post-1975 period. Indeed, across all earning groups, net migration losses were attenuated or net migration gains increased in 2010-2014.',
     descriptor: 'people whose earnings were'

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -54,6 +54,7 @@ function highlight(highlightData) {
 
   // update text area
   $('#char-display-name').text(characteristics[selectedCharacteristic].displayName + ' - ' + highlightData.group);
+  $('#char-display-parenthetical').text(characteristics[selectedCharacteristic].displayParenthetical || " ");
 
   var yearRange = highlightData.year_range.split('_').join(' and ');
   var direction = (highlightData.in > highlightData.out) ? '<span class="in">net gain' : '<span class="out">net loss';
@@ -81,6 +82,7 @@ function highlight(highlightData) {
 function updateTextArea(characteristic) {
   var thisCharacteristic = characteristics[characteristic];
   $('#char-display-name').text(thisCharacteristic.displayName);
+  $('#char-display-parenthetical').text(thisCharacteristic.displayParenthetical || " ");
   $('#char-about').text(thisCharacteristic.about);
 }
 


### PR DESCRIPTION
Commit adds two new span nodes to the header tag for the display name - the first span tag is the header name itself (with appropriate id) and the second is the parenthetical note, which is configured in the characteristics file.

Closes #19 
