### PR TITLE
change positioning of axis labels

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -177,11 +177,11 @@ function updateChart() {
 
   svg.selectAll('.in-label')
     .attr('x', 0)
-    .attr('y', margin.top + 100);
+    .attr('y', margin.top + 65);
 
   svg.selectAll('.out-label')
     .attr('x', 0)
-    .attr('y', height - margin.bottom - 50);
+    .attr('y', height - margin.bottom - 25);
 
   // add g elements for each chart, offset by outerX scale
   var g = svg.selectAll('g')


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR bumps out the static placement of the In-migration and out-migration labels so that there is no overlap with the bars in some category views.

Closes #20
